### PR TITLE
Use built-in chai expect messages

### DIFF
--- a/tasks/mocha_require_phantom.js
+++ b/tasks/mocha_require_phantom.js
@@ -119,8 +119,7 @@ module.exports = function(grunt) {
 				}
 				else if(evt === 'fail'){
 					writeIndented(msg.title.error, suiteLevel);
-					writeIndented(('expected: ' + msg.err.actual).warn, suiteLevel);
-					writeIndented(('actual: ' + msg.err.expected).warn, suiteLevel);
+					writeIndented(msg.err.message.warn, suiteLevel);
 					errorCount++;
 				}
 				else if(evt === 'pass'){
@@ -205,3 +204,4 @@ module.exports = function(grunt) {
 	});
 
 };
+


### PR DESCRIPTION
Expect messages are currently in the wrong order, and using patterns such as expect("foo").to.match(/bar/)  result in "undefined" instead of the pattern in the error output.

This fix uses the built-in messages from chai instead.
