### PR TITLE
console.log should handle large objects and null/undefined input

### DIFF
--- a/example/mocha-tests/test-console-log.js
+++ b/example/mocha-tests/test-console-log.js
@@ -1,0 +1,24 @@
+define([
+	'chai'
+], function(chai){
+
+	var expect = chai.expect;
+
+	describe('console.log', function(){
+		it('should not crash when printing null or undefined values', function(){
+			console.log(null);
+			console.log(undefined);
+		});
+
+		it('should cope with large and recursive data structures by limiting the output', function(){
+			var bigObj = {
+				1:{2:{3:{4:{5:{6:{7:{8:{9:{10:{11:""}}}}}}}}}},
+				2: 2, 3: 3, 4: 4, 5: 5, 6: 6, 7: 7, 8: 8, 9: 9,
+				10: 10, 11: 11, 12: 12, 13: 13, 14: 14, 15: 15,
+				16: 16, 17: 17, 18: 18, 19: 19, 20: 20, 21: 21
+			}
+			console.log(bigObj);
+		});
+	});
+
+});

--- a/lib/bridge.js
+++ b/lib/bridge.js
@@ -1,5 +1,8 @@
 (function(){
 
+	var maxConsoleLogRecursionDepth = 10;
+	var maxConsoleLogPropertiesPerObject = 20;
+
 	if(window.console && window.console.log){
 		var origConsoleLog = window.console.log;
 		
@@ -16,17 +19,32 @@
 			origConsoleLog.apply(window.console, arguments);
 		};
 	}
+
+	function consoleLog(val) {
+		var str = consoleLogRecur(val, maxConsoleLogRecursionDepth);
+		return str.replace(/,\s$/, '');
+	}
 	
-	function consoleLog(val){
+	function consoleLogRecur(val, depth){
 		if(isObject(val)){
 			var str = '{';
 			
+			var numProps = 0;
 			for(var attr in val){
+				numProps += 1;
+				if (numProps > maxConsoleLogPropertiesPerObject) {
+					str += "...";
+					break;
+				}
 			
 				var prop = '';
 			
 				if(isObject(val[attr])){
-					prop = consoleLog(val[attr]);
+					if (depth-1 === 0) {
+						prop = "{...}, "
+					} else {
+						prop = consoleLogRecur(val[attr], depth-1);
+					}
 				}
 				else{
 					prop = getConsoleVal(val[attr]) + ', ';
@@ -36,8 +54,8 @@
 			}
 			
 			str = str.replace(/,\s$/, '');
-			str += '}';
-			
+			str += '}, ';
+
 			return str;
 		}
 		else{
@@ -50,7 +68,11 @@
 			case 'string':
 				return '"' + val + '"';
 			default:
-				return val.toString();
+				if (val && val.toString) {
+					return val.toString();
+				} else {
+					return '';
+				}
 		}
 	}
 	


### PR DESCRIPTION
This stuff fixes two problems that I currently have with console logging:
- console.log will crash when the value being printed is null or undefined
- console.log will hang in infinite recursion when printing structures such as jquery objects

Potentially it would be nicer to print [null] vs [undefined] instead of nothing in the first scenario.
