### PR TITLE
Feature/npm 3 support

### DIFF
--- a/tasks/mocha_require_phantom.js
+++ b/tasks/mocha_require_phantom.js
@@ -202,11 +202,13 @@ module.exports = function(grunt) {
 		function copyFiles(){
 			var html, mochaJS, mochaCSS, bridge;
 
+			// Try NPM < 3 paths
 			try {
 				html = fs.readFileSync(__dirname + '/../lib/index.html', 'utf8');
 				mochaJS = fs.readFileSync(__dirname + '/../node_modules/mocha/mocha.js', 'utf8');
 				mochaCSS = fs.readFileSync(__dirname + '/../node_modules/mocha/mocha.css', 'utf8');
 				bridge = fs.readFileSync(__dirname + '/../lib/bridge.js', 'utf8');
+			// If there's an exception, use NPM 3 flattened paths
 			} catch (e) {
 				html = fs.readFileSync(__dirname + '/../lib/index.html', 'utf8');
 				mochaJS = fs.readFileSync(__dirname + '/../../mocha/mocha.js', 'utf8');

--- a/tasks/mocha_require_phantom.js
+++ b/tasks/mocha_require_phantom.js
@@ -170,7 +170,7 @@ module.exports = function(grunt) {
 			phantomjs.on('log', function(msg){
 				console.log(msg.log);
 			});
-			
+
 			phantomjs.on('error', function(msg){
 				grunt.fail.warn(msg);
 			});
@@ -200,10 +200,20 @@ module.exports = function(grunt) {
 		}
 
 		function copyFiles(){
-			var html = fs.readFileSync(__dirname + '/../lib/index.html', 'utf8'),
-				mochaJS = fs.readFileSync(__dirname + '/../node_modules/mocha/mocha.js', 'utf8'),
-				mochaCSS = fs.readFileSync(__dirname + '/../node_modules/mocha/mocha.css', 'utf8'),
+			var html, mochaJS, mochaCSS, bridge;
+
+			try {
+				html = fs.readFileSync(__dirname + '/../lib/index.html', 'utf8');
+				mochaJS = fs.readFileSync(__dirname + '/../node_modules/mocha/mocha.js', 'utf8');
+				mochaCSS = fs.readFileSync(__dirname + '/../node_modules/mocha/mocha.css', 'utf8');
 				bridge = fs.readFileSync(__dirname + '/../lib/bridge.js', 'utf8');
+			} catch (e) {
+				html = fs.readFileSync(__dirname + '/../lib/index.html', 'utf8');
+				mochaJS = fs.readFileSync(__dirname + '/../../mocha/mocha.js', 'utf8');
+				mochaCSS = fs.readFileSync(__dirname + '/../../mocha/mocha.css', 'utf8');
+				bridge = fs.readFileSync(__dirname + '/../lib/bridge.js', 'utf8');
+			}
+
 
 			grunt.file.write(tempDirectory + '/index.html', html, {
 				encoding: 'utf8'


### PR DESCRIPTION
NPM 3 flattens all of a project's dependencies to be inside of `project_root/node_modules`, which breaks grunt-mocha-require-phantom.  This change will add support for NPM 3 users.

I realize this is a pretty ugly way to fix the problem, but it works well enough for my use case.  I'm happy to go with a cleaner approach if you have any suggestions.

Thanks for making a really handy Node module!
